### PR TITLE
Fix to ignore processing broadcast blocks and transactions while not synced

### DIFF
--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -26,6 +26,7 @@ use crate::{
         comms_interface::{InboundNodeCommsHandlers, LocalNodeCommsInterface, OutboundNodeCommsInterface},
         proto,
         service::service::{BaseNodeService, BaseNodeServiceConfig, BaseNodeStreams},
+        StateMachineHandle,
     },
     blocks::NewBlock,
     chain_storage::{BlockchainBackend, BlockchainDatabase},
@@ -194,6 +195,10 @@ where T: BlockchainBackend + 'static
                 .get_handle::<ChainMetadataHandle>()
                 .expect("ChainMetadata handle required for BaseNodeService");
 
+            let state_machine = handles
+                .get_handle::<StateMachineHandle>()
+                .expect("StateMachineHandle required to initialize MempoolService");
+
             let streams = BaseNodeStreams::new(
                 outbound_request_stream,
                 outbound_block_stream,
@@ -203,8 +208,14 @@ where T: BlockchainBackend + 'static
                 local_request_stream,
                 local_block_stream,
             );
-            let service = BaseNodeService::new(outbound_message_service, inbound_nch, config, chain_metadata_handle)
-                .start(streams);
+            let service = BaseNodeService::new(
+                outbound_message_service,
+                inbound_nch,
+                config,
+                chain_metadata_handle,
+                state_machine,
+            )
+            .start(streams);
             futures::pin_mut!(service);
             future::select(service, shutdown).await;
             info!(target: LOG_TARGET, "Base Node Service shutdown");

--- a/base_layer/core/src/base_node/state_machine_service/handle.rs
+++ b/base_layer/core/src/base_node/state_machine_service/handle.rs
@@ -21,7 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::base_node::state_machine_service::states::{StateEvent, StatusInfo};
+use core::sync::atomic::{AtomicBool, Ordering};
 use futures::{stream::Fuse, StreamExt};
+use std::sync::Arc;
 use tari_broadcast_channel::Subscriber;
 use tari_shutdown::ShutdownSignal;
 
@@ -30,6 +32,7 @@ pub struct StateMachineHandle {
     state_change_event_subscriber: Subscriber<StateEvent>,
     status_event_subscriber: Subscriber<StatusInfo>,
     shutdown_signal: ShutdownSignal,
+    initial_blockchain_sync_success: Arc<AtomicBool>,
 }
 
 impl StateMachineHandle {
@@ -43,6 +46,7 @@ impl StateMachineHandle {
             state_change_event_subscriber,
             status_event_subscriber,
             shutdown_signal,
+            initial_blockchain_sync_success: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -70,5 +74,15 @@ impl StateMachineHandle {
 
     pub fn shutdown_signal(&self) -> ShutdownSignal {
         self.shutdown_signal.clone()
+    }
+
+    /// This lets any interested party update the the initial blockchain sync status
+    pub fn set_initial_blockchain_sync_success_status(&self, status: bool) {
+        self.initial_blockchain_sync_success.store(status, Ordering::Relaxed);
+    }
+
+    /// This lets any interested party know if the initial blockchain sync has been successful or not
+    pub fn get_initial_blockchain_sync_success_status(&self) -> bool {
+        self.initial_blockchain_sync_success.load(Ordering::SeqCst)
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/initializer.rs
+++ b/base_layer/core/src/base_node/state_machine_service/initializer.rs
@@ -122,6 +122,9 @@ where B: BlockchainBackend + 'static
             let node_local_interface = handles
                 .get_handle::<LocalNodeCommsInterface>()
                 .expect("Problem getting node local interface handle.");
+            let state_machine = handles
+                .get_handle::<StateMachineHandle>()
+                .expect("Problem getting StateMachineHandle");
 
             let mut state_machine_config = BaseNodeStateMachineConfig::default();
             state_machine_config.block_sync_config.sync_strategy = sync_strategy;
@@ -143,6 +146,7 @@ where B: BlockchainBackend + 'static
                 shutdown,
                 status_event_publisher,
                 state_event_publisher,
+                state_machine,
             );
 
             node.run().await;

--- a/base_layer/core/src/base_node/state_machine_service/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine_service/state_machine.rs
@@ -36,6 +36,7 @@ use crate::{
             },
         },
         validators::SyncValidators,
+        StateMachineHandle,
     },
     chain_storage::{BlockchainBackend, BlockchainDatabase},
 };
@@ -87,6 +88,7 @@ pub struct BaseNodeStateMachine<B> {
     event_publisher: Publisher<StateEvent>,
     interrupt_signal: ShutdownSignal,
     shutdown_trigger: Shutdown,
+    pub(crate) state_machine: StateMachineHandle,
 }
 
 impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
@@ -105,6 +107,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         shutdown_trigger: Shutdown,
         status_event_publisher: Publisher<StatusInfo>,
         event_publisher: Publisher<StateEvent>,
+        state_machine: StateMachineHandle,
     ) -> Self
     {
         Self {
@@ -121,6 +124,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
             status_event_publisher,
             sync_validators,
             shutdown_trigger,
+            state_machine,
         }
     }
 

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -88,6 +88,11 @@ impl Listening {
                         let sync_peers = select_sync_peers(local_tip_height, &best_metadata, &peer_metadata_list);
 
                         let sync_mode = determine_sync_mode(&local, best_metadata, sync_peers);
+                        if sync_mode == SyncStatus::UpToDate &&
+                            !shared.state_machine.get_initial_blockchain_sync_success_status()
+                        {
+                            shared.state_machine.set_initial_blockchain_sync_success_status(true);
+                        }
                         if sync_mode.is_lagging() {
                             debug!(target: LOG_TARGET, "{}", sync_mode);
                             return StateEvent::FallenBehind(sync_mode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `initial blockchain sync success status`; ignore processing broadcast blocks and transactions while not synced.

```
2020-09-03 14:36:28.559358700 [c::bn::base_node_service::service] DEBUG Propagated block 
  `7d86b867aff8b2c6aa516a25ae4c3eb76678c060519913ae69bdbb564cac399a` from peer `77505c9ac59e980c` not processed
  while busy with initial sync.
2020-09-03 14:45:24.531046200 [c::bn::base_node_service::service] DEBUG Propagated block 
  `6fc6a396b58078d77ae840ff079c8865b03aaa9fe5e8c14b7257b8c4dcf709d5` from peer `75cfb63f1e967a5d` not processed
  while busy with initial sync.
2020-09-03 15:17:25.387416500 [c::mempool::service::service] DEBUG Transaction with Message 
  Tag#14549752373440131633 from peer `099fc6fc362f07b5` not processed while busy with initial sync.
2020-09-03 15:31:48.791373000 [c::mempool::service::service] DEBUG Transaction with Message 
  Tag#17433793954531681364 from peer `d1085ff28065d04d` not processed while busy with initial sync.
```

## Motivation and Context

Blockchain sync must be allowed to continue uninterrupted and not let the basenode do unnecessary work.

## How Has This Been Tested?

Tested in a basenode running in Window 10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
